### PR TITLE
Anvil sync fix

### DIFF
--- a/evaisa.arena/content/data.lua
+++ b/evaisa.arena/content/data.lua
@@ -539,6 +539,9 @@ arena_list = {
         spawn_points = { -- optional, can also use spawn pixels, 0,0 is there as a backup in case spawn pixels fail somehow.
             {x = 0, y = 0}
         },
+        load = function(self, lobby, data)
+            GameAddFlagRun("forge_reset")
+        end,
         zone_size = 600, -- size of damage zone, should be max distance from 0, 0 players can travel
         zone_floor = 400 -- damage floor, if player falls below this they die.
     },

--- a/evaisa.arena/data/scripts/buildings/forge_item_convert.lua
+++ b/evaisa.arena/data/scripts/buildings/forge_item_convert.lua
@@ -8,6 +8,10 @@ local pos_x, pos_y = EntityGetTransform( entity_id )
 -- convert items
 local converted = false
 
+if GameHasFlagRun("forge_reset") then
+	forge_converts = 0
+	GameRemoveFlagRun("forge_reset")
+end
 
 for _,id in pairs(EntityGetInRadiusWithTag(pos_x, pos_y, 70, "leukaluu")) do
 	-- make sure item is not carried in inventory or wand
@@ -52,8 +56,13 @@ end
 for _,id in pairs(EntityGetInRadiusWithTag(pos_x, pos_y, 70, "broken_wand")) do
 	-- make sure item is not carried in inventory or wand
 	if EntityGetRootEntity(id) == id then
+		SetRandomSeed( pos_x, pos_y )
+		local offset_x = ProceduralRandomi( forge_converts, 0, -35, 35 )
+		local offset_y = ProceduralRandomi( forge_converts, 0, -10, 5 )
+		forge_converts = forge_converts + 1
+		-- GamePrint("Forged items:"..forge_converts)
 		local x,y = EntityGetTransform(id)
-		EntityHelper.NetworkRegister(EntityLoad("data/entities/items/wand_level_05_better.xml", x, y - 5), math.floor(pos_x + x), math.floor(pos_y + y))
+		EntityHelper.NetworkRegister(EntityLoad("data/entities/items/wand_level_05_better.xml", pos_x + offset_x, pos_y + offset_y + 15), math.floor(pos_x + offset_x ), math.floor(pos_y + offset_y + 15))
 		EntityLoad("data/entities/projectiles/explosion.xml", x, y - 10)
 		EntityKill(id)
 		converted = true


### PR DESCRIPTION
Change wand spawn position to use converter entity position + random synchronised offset across clients. 

Add counter for amount of conversions, reset counter when map loads to prevent counter desyncing across lobbies.

Add forge reset flag on Foundry map load